### PR TITLE
backtick command added

### DIFF
--- a/help/manipulator.md
+++ b/help/manipulator.md
@@ -32,12 +32,13 @@ The following commands currently exists:
  * `incNum`: Increase number by one
  * `decNum`: Decrease number by one
  * `capital`: Capitalize First Letter
- * `brace`: Adds brackets around selection 
+ * `brace`: Adds brackets around selection
      * `curly`: Curly brackets (`{ }`)
      * `square`: Square brackets (`[ ]`)
 	 * `angle`: Angle brackets (`< >`)
      * `dquote`: Double quotes (`" "`)
      * `squote`: Single quotes (`' '`)
+     * `backtick`: Backticks (`` ` ` ``)
 
 ## Issues
 

--- a/manipulator.lua
+++ b/manipulator.lua
@@ -1,4 +1,4 @@
-VERSION = "1.4.0"
+VERSION = "1.4.1"
 
 local micro = import("micro")
 local config = import("micro/config")
@@ -148,6 +148,7 @@ function init()
     config.MakeCommand("dquote", function() manipulate(".*", '"%1"', 1) end, config.NoComplete)
     config.MakeCommand("squote", function() manipulate(".*", "'%1'", 1) end, config.NoComplete)
     config.MakeCommand("angle", function() manipulate(".*", "<%1>", 1) end, config.NoComplete)
+    config.MakeCommand("backtick", function() manipulate(".*", "`%1`", 1) end, config.NoComplete)
     config.MakeCommand("base64dec", base64dec, config.NoComplete)
     config.MakeCommand("base64enc", base64enc, config.NoComplete)
     config.MakeCommand("decNum", decNum, config.NoComplete)


### PR DESCRIPTION
This commit addresses this issue: https://github.com/micro-editor/updated-plugins/issues/20

It adds the possibility to surround a text with backticks (`` ` ` ``). The command to use:

    > backtick
